### PR TITLE
PR #24 cleanup

### DIFF
--- a/spring-cloud-starter-stream-artemis-it/spring-cloud-starter-stream-artemis-it-e2e/src/test/java/me/snowdrop/stream/binder/artemis/AnonymousGroupEndToEndIT.java
+++ b/spring-cloud-starter-stream-artemis-it/spring-cloud-starter-stream-artemis-it-e2e/src/test/java/me/snowdrop/stream/binder/artemis/AnonymousGroupEndToEndIT.java
@@ -39,8 +39,7 @@ import static org.awaitility.Awaitility.await;
         properties = {
                 "spring.cloud.stream.bindings.output.destination=anonymous-destination",
                 "spring.cloud.stream.bindings.input.destination=anonymous-destination",
-                "spring.cloud.stream.bindings.alternativeInput.destination=anonymous-destination",
-                "spring.jms.cache.enabled=false"
+                "spring.cloud.stream.bindings.alternativeInput.destination=anonymous-destination"
         }
 )
 @Import({ StringStreamSource.class, StringStreamListener.class, AlternativeStringStreamListener.class })

--- a/spring-cloud-starter-stream-artemis-it/spring-cloud-starter-stream-artemis-it-e2e/src/test/java/me/snowdrop/stream/binder/artemis/DynamicDestinationIT.java
+++ b/spring-cloud-starter-stream-artemis-it/spring-cloud-starter-stream-artemis-it-e2e/src/test/java/me/snowdrop/stream/binder/artemis/DynamicDestinationIT.java
@@ -30,7 +30,6 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.jms.core.JmsTemplate;
-import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit4.SpringRunner;
 
 import static me.snowdrop.stream.binder.artemis.common.NamingUtils.getQueueName;
@@ -40,10 +39,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author <a href="mailto:gytis@redhat.com">Gytis Trikleris</a>
  */
 @RunWith(SpringRunner.class)
-@SpringBootTest(
-        classes = StreamApplication.class,
-        properties = {"spring.jms.cache.enabled=false" }
-)
+@SpringBootTest(classes = StreamApplication.class)
 @Import({ DynamicDestinationIT.TestConfiguration.class, DynamicDestinationSource.class })
 public class DynamicDestinationIT {
 

--- a/spring-cloud-starter-stream-artemis-it/spring-cloud-starter-stream-artemis-it-e2e/src/test/java/me/snowdrop/stream/binder/artemis/ExistingAddressIT.java
+++ b/spring-cloud-starter-stream-artemis-it/spring-cloud-starter-stream-artemis-it-e2e/src/test/java/me/snowdrop/stream/binder/artemis/ExistingAddressIT.java
@@ -24,7 +24,6 @@ import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
-import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit4.SpringRunner;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
@@ -40,8 +39,7 @@ import static org.awaitility.Awaitility.await;
         properties = {
                 "spring.artemis.embedded.queues=existing-destination",
                 "spring.cloud.stream.bindings.output.destination=existing-destination",
-                "spring.cloud.stream.bindings.input.destination=existing-destination",
-                "spring.jms.cache.enabled=false"
+                "spring.cloud.stream.bindings.input.destination=existing-destination"
         }
 )
 @Import({ StringStreamSource.class, StringStreamListener.class })

--- a/spring-cloud-starter-stream-artemis-it/spring-cloud-starter-stream-artemis-it-e2e/src/test/java/me/snowdrop/stream/binder/artemis/ModifiedAddressSettingsIT.java
+++ b/spring-cloud-starter-stream-artemis-it/spring-cloud-starter-stream-artemis-it-e2e/src/test/java/me/snowdrop/stream/binder/artemis/ModifiedAddressSettingsIT.java
@@ -15,6 +15,8 @@
  */
 package me.snowdrop.stream.binder.artemis;
 
+import javax.jms.ConnectionFactory;
+
 import me.snowdrop.stream.binder.artemis.application.StreamApplication;
 import me.snowdrop.stream.binder.artemis.listeners.IntegerStreamListener;
 import org.apache.activemq.artemis.api.core.client.ClientMessage;
@@ -30,7 +32,7 @@ import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
-import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.jms.connection.SingleConnectionFactory;
 import org.springframework.test.context.junit4.SpringRunner;
 
 import static org.apache.activemq.artemis.api.core.management.ResourceNames.BROKER;
@@ -52,19 +54,17 @@ import static org.assertj.core.api.Assertions.assertThat;
                 "spring.cloud.stream.artemis.bindings.input.consumer.brokerRedeliveryDelayMultiplier=3.0",
                 "spring.cloud.stream.artemis.bindings.input.consumer.brokerMaxDeliveryAttempts=4",
                 "spring.cloud.stream.artemis.bindings.input.consumer.brokerSendToDlaOnNoRoute=true",
-                "spring.jms.cache.enabled=false"
         }
 )
 @Import({ IntegerStreamListener.class })
 public class ModifiedAddressSettingsIT {
 
     @Autowired
-    private ActiveMQConnectionFactory connectionFactory;
+    private ConnectionFactory connectionFactory;
 
     @Test
     public void shouldGetModifiedAddressSettings() throws Exception {
-        ServerLocator serverLocator = connectionFactory.getServerLocator();
-        try (ClientSessionFactory sessionFactory = serverLocator.createSessionFactory();
+        try (ClientSessionFactory sessionFactory = getServerLocator(connectionFactory).createSessionFactory();
              ClientSession session = sessionFactory.createSession();
              ClientRequestor requestor = new ClientRequestor(session, "activemq.management")) {
             session.start();
@@ -86,4 +86,13 @@ public class ModifiedAddressSettingsIT {
         }
     }
 
+    private ServerLocator getServerLocator(ConnectionFactory connectionFactory) {
+        if (connectionFactory instanceof ActiveMQConnectionFactory) {
+            return ((ActiveMQConnectionFactory) connectionFactory).getServerLocator();
+        }
+        if (connectionFactory instanceof SingleConnectionFactory) {
+            return getServerLocator(((SingleConnectionFactory) connectionFactory).getTargetConnectionFactory());
+        }
+        throw new RuntimeException("Unsupported connection factory " + connectionFactory.getClass().getName());
+    }
 }

--- a/spring-cloud-starter-stream-artemis-it/spring-cloud-starter-stream-artemis-it-e2e/src/test/java/me/snowdrop/stream/binder/artemis/MultipleGroupsEndToEndIT.java
+++ b/spring-cloud-starter-stream-artemis-it/spring-cloud-starter-stream-artemis-it-e2e/src/test/java/me/snowdrop/stream/binder/artemis/MultipleGroupsEndToEndIT.java
@@ -25,7 +25,6 @@ import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
-import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit4.SpringRunner;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
@@ -43,8 +42,7 @@ import static org.awaitility.Awaitility.await;
                 "spring.cloud.stream.bindings.input.destination=multiple-groups-destination",
                 "spring.cloud.stream.bindings.alternativeInput.destination=multiple-groups-destination",
                 "spring.cloud.stream.bindings.input.group=group-1",
-                "spring.cloud.stream.bindings.alternativeInput.group=group-2",
-                "spring.jms.cache.enabled=false"
+                "spring.cloud.stream.bindings.alternativeInput.group=group-2"
         }
 )
 @Import({ StringStreamSource.class, StringStreamListener.class, AlternativeStringStreamListener.class })

--- a/spring-cloud-starter-stream-artemis-it/spring-cloud-starter-stream-artemis-it-e2e/src/test/java/me/snowdrop/stream/binder/artemis/PrimitivePayloadIT.java
+++ b/spring-cloud-starter-stream-artemis-it/spring-cloud-starter-stream-artemis-it-e2e/src/test/java/me/snowdrop/stream/binder/artemis/PrimitivePayloadIT.java
@@ -23,7 +23,6 @@ import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
-import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit4.SpringRunner;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
@@ -34,8 +33,7 @@ import static org.awaitility.Awaitility.await;
         classes = StreamApplication.class,
         properties = {
                 "spring.cloud.stream.bindings.output.destination=primitive-destination",
-                "spring.cloud.stream.bindings.input.destination=primitive-destination",
-                "spring.jms.cache.enabled=false"
+                "spring.cloud.stream.bindings.input.destination=primitive-destination"
         }
 )
 @Import({ IntegerStreamSource.class, IntegerStreamListener.class })

--- a/spring-cloud-starter-stream-artemis-it/spring-cloud-starter-stream-artemis-it-e2e/src/test/java/me/snowdrop/stream/binder/artemis/RetryIT.java
+++ b/spring-cloud-starter-stream-artemis-it/spring-cloud-starter-stream-artemis-it-e2e/src/test/java/me/snowdrop/stream/binder/artemis/RetryIT.java
@@ -25,8 +25,7 @@ import static org.hamcrest.Matchers.equalTo;
                 "spring.cloud.stream.bindings.output.destination=failing-destination",
                 "spring.cloud.stream.bindings.input.destination=failing-destination",
                 "spring.cloud.stream.bindings.input.group=failing-group",
-                "spring.cloud.stream.bindings.input.consumer.back-off-multiplier=1",
-                "spring.jms.cache.enabled=false"
+                "spring.cloud.stream.bindings.input.consumer.back-off-multiplier=1"
         }
 )
 @Import({ StringStreamSource.class, FailingStreamListener.class })

--- a/spring-cloud-starter-stream-artemis-it/spring-cloud-starter-stream-artemis-it-e2e/src/test/java/me/snowdrop/stream/binder/artemis/SingleGroupEndToEndIT.java
+++ b/spring-cloud-starter-stream-artemis-it/spring-cloud-starter-stream-artemis-it-e2e/src/test/java/me/snowdrop/stream/binder/artemis/SingleGroupEndToEndIT.java
@@ -48,8 +48,7 @@ import static org.awaitility.Awaitility.await;
                 "spring.cloud.stream.bindings.alternativeInput.group=group-1",
                 // causes issues when registering two error channel beans which share the same name
                 "spring.cloud.stream.bindings.input.consumer.max-attempts=1",
-                "spring.cloud.stream.bindings.alternativeInput.consumer.max-attempts=1",
-                "spring.jms.cache.enabled=false"
+                "spring.cloud.stream.bindings.alternativeInput.consumer.max-attempts=1"
         }
 )
 @Import({ StringStreamSource.class, StringStreamListener.class, AlternativeStringStreamListener.class })

--- a/spring-cloud-starter-stream-artemis-it/spring-cloud-starter-stream-artemis-it-partition/src/test/java/me/snowdrop/stream/binder/artemis/PartitionCapableBinderIT.java
+++ b/spring-cloud-starter-stream-artemis-it/spring-cloud-starter-stream-artemis-it-partition/src/test/java/me/snowdrop/stream/binder/artemis/PartitionCapableBinderIT.java
@@ -16,8 +16,6 @@
 
 package me.snowdrop.stream.binder.artemis;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.List;
@@ -57,12 +55,16 @@ import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.util.Assert;
 import org.springframework.util.MimeTypeUtils;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 /**
  * @author <a href="mailto:gytis@redhat.com">Gytis Trikleris</a>
  */
 @RunWith(SpringRunner.class)
-@SpringBootTest(classes = StreamApplication.class,
-        properties = { "spring.jms.cache.enabled=false"})
+@SpringBootTest(
+        classes = StreamApplication.class,
+        properties = "spring.jms.cache.enabled=false"
+)
 @Import({ ArtemisAutoConfiguration.class, ArtemisBinderAutoConfiguration.class })
 @DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_CLASS)
 public class PartitionCapableBinderIT extends

--- a/spring-cloud-starter-stream-artemis-it/spring-cloud-starter-stream-artemis-it-processor/src/test/java/me/snowdrop/stream/binder/artemis/ArtemisBinderWithStreamProcessorIT.java
+++ b/spring-cloud-starter-stream-artemis-it/spring-cloud-starter-stream-artemis-it-processor/src/test/java/me/snowdrop/stream/binder/artemis/ArtemisBinderWithStreamProcessorIT.java
@@ -37,10 +37,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author <a href="mailto:gytis@redhat.com">Gytis Trikleris</a>
  */
 @RunWith(SpringRunner.class)
-@SpringBootTest(
-        classes = StreamApplication.class,
-        properties = "spring.jms.cache.enabled=false"
-)
+@SpringBootTest(classes = StreamApplication.class)
 public class ArtemisBinderWithStreamProcessorIT {
 
     @Autowired

--- a/spring-cloud-starter-stream-artemis-samples/multi-io/src/test/java/demo/ModuleApplicationTests.java
+++ b/spring-cloud-starter-stream-artemis-samples/multi-io/src/test/java/demo/ModuleApplicationTests.java
@@ -25,7 +25,7 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.context.web.WebAppConfiguration;
 
 @RunWith(SpringJUnit4ClassRunner.class)
-@SpringBootTest(classes = MultipleIOChannelsApplication.class, properties = {"spring.jms.cache.enabled=false"})
+@SpringBootTest(classes = MultipleIOChannelsApplication.class)
 @WebAppConfiguration
 @DirtiesContext
 public class ModuleApplicationTests {

--- a/spring-cloud-stream-binder-artemis/src/main/java/me/snowdrop/stream/binder/artemis/ArtemisMessageChannelBinder.java
+++ b/spring-cloud-stream-binder-artemis/src/main/java/me/snowdrop/stream/binder/artemis/ArtemisMessageChannelBinder.java
@@ -16,10 +16,6 @@
 
 package me.snowdrop.stream.binder.artemis;
 
-import static me.snowdrop.stream.binder.artemis.common.NamingUtils.getAnonymousGroupName;
-import static me.snowdrop.stream.binder.artemis.common.NamingUtils.getQueueName;
-import static org.springframework.cloud.stream.binder.BinderHeaders.PARTITION_HEADER;
-
 import javax.jms.ConnectionFactory;
 
 import me.snowdrop.stream.binder.artemis.listener.ListenerContainerFactory;
@@ -46,12 +42,16 @@ import org.springframework.messaging.MessageHandler;
 import org.springframework.retry.support.RetryTemplate;
 import org.springframework.util.StringUtils;
 
+import static me.snowdrop.stream.binder.artemis.common.NamingUtils.getAnonymousGroupName;
+import static me.snowdrop.stream.binder.artemis.common.NamingUtils.getQueueName;
+import static org.springframework.cloud.stream.binder.BinderHeaders.PARTITION_HEADER;
+
 /**
  * @author <a href="mailto:gytis@redhat.com">Gytis Trikleris</a>
  */
 public class ArtemisMessageChannelBinder extends
-        AbstractMessageChannelBinder<ExtendedConsumerProperties<ArtemisConsumerProperties>, ExtendedProducerProperties<ArtemisProducerProperties>,
-                ArtemisProvisioningProvider>
+        AbstractMessageChannelBinder<ExtendedConsumerProperties<ArtemisConsumerProperties>,
+                ExtendedProducerProperties<ArtemisProducerProperties>, ArtemisProvisioningProvider>
         implements ExtendedPropertiesBinder<MessageChannel, ArtemisConsumerProperties, ArtemisProducerProperties> {
 
     private static final String[] DEFAULT_HEADERS = new String[0];
@@ -73,9 +73,9 @@ public class ArtemisMessageChannelBinder extends
         logger.debug("Creating producer message handler for '" + destination + "'");
 
         JmsSendingMessageHandler handler = Jms.outboundAdapter(connectionFactory)
-                                              .destination(message -> getMessageDestination(message, destination))
-                                              .configureJmsTemplate(templateSpec -> templateSpec.pubSubDomain(true))
-                                              .get();
+                .destination(message -> getMessageDestination(message, destination))
+                .configureJmsTemplate(templateSpec -> templateSpec.pubSubDomain(true))
+                .get();
         handler.setApplicationContext(getApplicationContext());
         handler.setBeanFactory(getBeanFactory());
 
@@ -87,7 +87,7 @@ public class ArtemisMessageChannelBinder extends
             ExtendedConsumerProperties<ArtemisConsumerProperties> properties) {
         logger.debug("Creating consumer endpoint for '{" + destination + "}' with a group '{" + group + "}'");
 
-        if ( !StringUtils.hasText(group) ) {
+        if (!StringUtils.hasText(group)) {
             group = getAnonymousGroupName();
         }
 
@@ -96,7 +96,7 @@ public class ArtemisMessageChannelBinder extends
         AbstractMessageListenerContainer listenerContainer = listenerContainerFactory
                 .getListenerContainer(destination.getName(), subscriptionName);
 
-        if ( properties.getMaxAttempts() == 1 ) {
+        if (properties.getMaxAttempts() == 1) {
             return Jms.messageDrivenChannelAdapter(listenerContainer).get();
         }
 
@@ -131,7 +131,7 @@ public class ArtemisMessageChannelBinder extends
     @Override
     protected String errorsBaseName(ConsumerDestination destination, String group,
             ExtendedConsumerProperties<ArtemisConsumerProperties> properties) {
-        if ( group == null ) {
+        if (group == null) {
             /*
             This is a workaround to not get NPE when calling getQueueName.
             Such situation occurs with anonymous groups during the destroyErrorInfrastructure execution.
@@ -146,15 +146,15 @@ public class ArtemisMessageChannelBinder extends
 
     private String getMessageDestination(Message<?> message, ProducerDestination destination) {
         Object partition = message.getHeaders()
-                                  .get(PARTITION_HEADER);
+                .get(PARTITION_HEADER);
 
-        if ( partition == null ) {
+        if (partition == null) {
             return destination.getName();
         }
-        if ( partition instanceof Integer ) {
+        if (partition instanceof Integer) {
             return destination.getNameForPartition((Integer) partition);
         }
-        if ( partition instanceof String ) {
+        if (partition instanceof String) {
             return destination.getNameForPartition(Integer.parseInt((String) partition));
         }
         throw new IllegalArgumentException(

--- a/spring-cloud-stream-binder-artemis/src/test/java/me/snowdrop/stream/binder/artemis/ArtemisMessageChannelBinderTest.java
+++ b/spring-cloud-stream-binder-artemis/src/test/java/me/snowdrop/stream/binder/artemis/ArtemisMessageChannelBinderTest.java
@@ -1,8 +1,5 @@
 package me.snowdrop.stream.binder.artemis;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.BDDMockito.given;
-
 import me.snowdrop.stream.binder.artemis.listener.RetryableChannelPublishingJmsMessageListener;
 import me.snowdrop.stream.binder.artemis.properties.ArtemisConsumerProperties;
 import me.snowdrop.stream.binder.artemis.provisioning.ArtemisConsumerDestination;
@@ -20,6 +17,9 @@ import org.springframework.integration.jms.JmsMessageDrivenEndpoint;
 import org.springframework.integration.jms.JmsSendingMessageHandler;
 import org.springframework.messaging.MessageHandler;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
 /**
  * @author <a href="mailto:gytis@redhat.com">Gytis Trikleris</a>
  */
@@ -32,16 +32,12 @@ public class ArtemisMessageChannelBinderTest {
     @Mock
     private DefaultListableBeanFactory mockBeanFactory;
 
-    private GenericApplicationContext mockApplicationContext;
-
     private ArtemisMessageChannelBinder binder;
 
     @Before
     public void before() {
-        mockApplicationContext = new GenericApplicationContext(mockBeanFactory);
-
         binder = new ArtemisMessageChannelBinder(null, null, null);
-        binder.setApplicationContext(mockApplicationContext);
+        binder.setApplicationContext(new GenericApplicationContext(mockBeanFactory));
     }
 
     @Test


### PR DESCRIPTION
@aklemanovits here are a few cleanup changes and a fix to make the binder work without requiring `spring.jms.cache.enabled=false`. If you'd merge this in your side we should be able to run the CI together with your changes and merge it if everything is OK.